### PR TITLE
removed call to resize that would make the player blackout

### DIFF
--- a/demos/advanced/minimize-and-float-video-on-scroll/js/main.js
+++ b/demos/advanced/minimize-and-float-video-on-scroll/js/main.js
@@ -58,7 +58,7 @@ playerInstance.on('ready', function() {
 
             utils.toggleClass(playerContainerEl, 'player-minimize', minimize);
             // update the player's size so the controls are adjusted
-            playerInstance.resize();
+//             playerInstance.resize(); This causes the player to black out in recent releases
         }
 
         // namespace for whether or not we are waiting for setTimeout() to finish


### PR DESCRIPTION
You can see my updated demo page live here:
http://qa.jwplayer.com.s3.amazonaws.com/~george/scroll_float_demo.html

Currently this is how it behaves:
https://developer.jwplayer.com/jw-player/demos/advanced/minimize-and-float-video-on-scroll/