### PR TITLE
[WEB-687] Fix demo by delaying init until jwplayer global var exists

### DIFF
--- a/_templates/js.mustache
+++ b/_templates/js.mustache
@@ -1,8 +1,17 @@
 <script type="text/javascript">{{{js}}}</script>
 <script type="text/javascript">
-if (jwplayer().id) {
-	jwplayer().on('ready', function() {
-		document.getElementById('demo-player-version').innerHTML = jwplayer.version.split('+')[0];
-	});
-}
+  function setVersion() {
+    if (typeof jwplayer === 'undefined') {
+      setTimeout(setVersion, 100);
+      return;
+    }
+
+    if (jwplayer && jwplayer().id) {
+      jwplayer().on('ready', function() {
+        document.getElementById('demo-player-version').innerHTML = jwplayer.version.split('+')[0];
+      });
+    }
+  }
+
+  setVersion();
 </script>

--- a/demos/toolbox/performance-tracking/index.html
+++ b/demos/toolbox/performance-tracking/index.html
@@ -23,32 +23,36 @@
 <p>The JW Player JavaScript API can be used to integrate with third party QoE systems. See our <a href="//developer.jwplayer.com/jw-player/docs/developer-guide/api/javascript_api_reference/">JavaScript API Reference</a> for all available QoE/QoS events.</p>
 
 <script src='testing-utils.js'></script>
-<script src='//content.jwplatform.com/libraries/z3exF2NE.js'></script>
 <script type="text/javascript">
 
   function onLoad() {
-    var playerVersion;
     var libraryRadios = document.querySelectorAll('.version-toggle');
-    if (window.location.search) {
-      playerVersion = window.location.search.split("=")[1];
-    } else {
-      playerVersion = 8;
-    }
+    var playerVersion = window.location.search ?
+      window.location.search.split("playerversion=")[1] :
+      '8';
+
     libraryRadios.forEach(function(radio) {
       radio.addEventListener('click', switchPlayerLibrary);
-      radio.checked = radio.value == playerVersion;
+      radio.checked = radio.value === playerVersion;
     });
+
     setLibraryScript(playerVersion);
   };
 
   function setLibraryScript(playerVersion) {
+    var playerLibraries = {
+      7: 'https://content.jwplatform.com/libraries/z3exF2NE.js',
+      8: 'https://content.jwplatform.com/libraries/Jq6HIbgz.js'
+    };
     var script = document.createElement('script');
-    playerVersion == 8 ? script.src = "https://content.jwplatform.com/libraries/Jq6HIbgz.js" : script.src = "https://content.jwplatform.com/libraries/z3exF2NE.js";
+
+    script.src = playerLibraries[playerVersion];
     document.body.appendChild(script);
   };
 
   function switchPlayerLibrary(e) {
     var version = e.target.value;
+
     window.location.search = 'playerversion=' + version;
   };
 

--- a/demos/toolbox/performance-tracking/js/main.js
+++ b/demos/toolbox/performance-tracking/js/main.js
@@ -1,27 +1,31 @@
-var logs = jwTest.makeLogger('container');
+function init() {
+  var player, logs;
 
-function prettify(q, event) {
-  if (!q.item.counts[event] && !q.item.sums[event]) {
-      return event + ' (undefined)';
+  // For demo purposes
+  if (typeof jwplayer === 'undefined') {
+    setTimeout(init, 100);
+    return;
   }
-  return event + ' ('+q.item.counts[event]+') ' + q.item.sums[event];
+
+  player = jwplayer('container');
+  logs = jwTest.makeLogger('container');
+
+  player.setup({
+    displaytitle: false,
+    preload:'metadata',
+    file: '//content.jwplatform.com/videos/i3q4gcBi.mp4',
+    image:'//content.jwplatform.com/thumbs/i3q4gcBi.jpg'
+  });
+
+  player.on('ready', function() {
+    var qoe = this.qoe();
+    logs.log('The player set up in', JSON.stringify(qoe.setupTime),'ms.');
+  });
+
+  player.on('firstFrame', function() {
+    var qoe = this.qoe();
+    logs.log('The player took', JSON.stringify(qoe.firstFrame),'ms to get to the first frame of video.');
+  });
 }
 
-var player = jwplayer('container');
-
-player.setup({
-  displaytitle: false,
-  preload:'metadata',
-  file: '//content.jwplatform.com/videos/i3q4gcBi.mp4',
-  image:'//content.jwplatform.com/thumbs/i3q4gcBi.jpg'
-});
-
-player.on('ready', function() {
-  var qoe = this.qoe();
-  logs.log('The player set up in', JSON.stringify(qoe.setupTime),'ms.');
-});
-
-player.on('firstFrame', function() {
-  var qoe = this.qoe();
-  logs.log('The player took', JSON.stringify(qoe.firstFrame),'ms to get to the first frame of video.');
-});
+init();


### PR DESCRIPTION
The main gist of what I did was invoke a setTimeout in areas where the jwplayer object is expected to exist on load. Since we're toggling the player version and we can't have two libraries on the page at the same time (this is by design), we're setting the player library script on the fly. This is slower than embedding it on the page - which is what normal usage would entail - and makes it run immediately.

Note that I had to do this same thing in a core template file which basically just sets the player version based on the version of the jwplayer global object. This file is automatically appended to each demo on build time.

**Final thought:** as you can see, toggling player versions is not at all ideal, and I would highly advocate we stop doing it, unless the player is changed in such a way that appending a second player library overrides the first one (which I doubt is going to happen anytime soon).