### PR TITLE
Video player bidding

### DIFF
--- a/demos/advanced/video-player-bidding/config.json
+++ b/demos/advanced/video-player-bidding/config.json
@@ -8,7 +8,7 @@
 		"on('adImpression')", "on('adBidRequest')", "on('adBidResponse')"
 	],
 	"author": {
-		"name": "JW Player",
-		"githubUsername": "jwplayer"
+		"name": "Ian Boynton",
+		"githubUsername": "boyntoni"
 	}
 }

--- a/demos/advanced/video-player-bidding/config.json
+++ b/demos/advanced/video-player-bidding/config.json
@@ -1,0 +1,14 @@
+{
+	"title": "Video Player Bidding",
+	"description": "Use JW Player for player bidding with SpotXchange.",
+	"license": "Enterprise",
+	"showCode": false,
+    "layout": "vertical",
+ 	"apiCalls": [
+		"on('adImpression')", "on('adBidRequest')", "on('adBidResponse')"
+	],
+	"author": {
+		"name": "JW Player",
+		"githubUsername": "jwplayer"
+	}
+}

--- a/demos/advanced/video-player-bidding/css/main.css
+++ b/demos/advanced/video-player-bidding/css/main.css
@@ -1,0 +1,65 @@
+/* Ensure that the player uses all available width */
+.container .demo-layout-vertical .demo-layout-content {
+	max-width: 100%;
+	min-width: 0;
+}
+
+.instructions h3 {
+	font-size: 17px;
+	font-weight: 500;
+	text-transform: uppercase;
+}
+
+.instructions h4 {
+	font-size: 13px;
+	font-weight: 500;
+	margin-top: 20px;
+	margin-bottom: 20px;
+}
+
+
+.steps {
+	display: flex;
+	flex: 1;
+	flex-direction: row;
+	margin-bottom: 30px;
+	padding-bottom: 30px;
+	border-bottom: 1px solid #ccc;
+	justify-content: space-around;
+	align-items: center;
+}
+
+.setup-steps {
+	display: flex;
+	flex-direction: column;
+	min-width: 25%;
+	text-align: center;
+}
+
+@media (max-width: 640px) {
+	.steps {
+		flex-direction: column;
+	}
+}
+
+#dfp {
+	display: block;
+}
+
+#jwp {
+	display: none;
+}
+
+#mediationLayerSelect {
+	text-align: center;
+}
+
+.pageDescription {
+	margin-top: 20px;
+	margin-bottom: 20px;
+}
+
+#title {
+	font-size: 30px;
+	font-weight: bold;
+}

--- a/demos/advanced/video-player-bidding/index.html
+++ b/demos/advanced/video-player-bidding/index.html
@@ -1,0 +1,100 @@
+<!--
+* Copyright 2016 Longtail Ad Solutions Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language
+* governing permissions and limitations under the License.
+-->
+<script src="//content.jwplatform.com/libraries/lqsWlr4Z.js"></script>
+<div class="pageDescription">
+    <p>This page demonstrates JW Player's new SpotX bidding integration. This is placeholder text for now to see what this looks like.</p>
+</div>
+<div id="myElement"></div>
+<div class="instructions">
+	<div class="steps">
+		<div class="setup-steps">
+            <h3 id="bid-request">(no ad bid request yet)</h3>
+            <h3 id="bid-response">(no ad bid response yet)</h3>
+            <h3 id="impression">(no ad impression yet)</h3>
+        </div>
+        <div class="setup-steps">
+            <p>Select Mediation Layer</p>
+            <select id="mediationLayerSelect">
+                <option value="dfp">DFP</option>
+                <option value="jwp">JW Player</option>
+            </select>
+        </div>
+    </div>
+    <h1 id="title">Code Example</h1>
+        <pre>
+            <code id="dfp">
+            var playerInstance = jwplayer("myElement")
+            playerInstance.setup({
+                "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",
+                "advertising": {
+                    "client": "googima",
+                    "schedule": {
+                        "adBreak": {
+                            "tag": "//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=sample_ct%3Dskippablelinear&correlator=",
+                            "offset": "pre"
+                        }
+                    },
+                    "bids": {
+                        "settings": {
+                            "mediationLayerAdServer": "dfp",
+                            "floorPriceCents": 2,
+                            "floorPriceCurrency": "usd",
+                            "bidTimeout": 1000
+                        },
+                        "bidders": [
+                            {
+                                "name": "SpotX",
+                                "id": "218150"
+                            }
+                        ]
+                    }
+                }
+            });
+            </code>
+            <code id="jwp">
+                    var playerInstance = jwplayer("myElement")
+                    playerInstance.setup({
+                        "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",
+                        "advertising": {
+                            "client": "googima",
+                            "schedule": {
+                                "adBreak": {
+                                    "tag": "//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=sample_ct%3Dskippablelinear&correlator=",
+                                    "offset": "pre"
+                                }
+                            },
+                            "bids": {
+                                "settings": {
+                                    "mediationLayerAdServer": "jwp",
+                                    "floorPriceCents": 2,
+                                    "floorPriceCurrency": "usd",
+                                    "bidTimeout": 1000
+                                },
+                                "bidders": [
+                                    {
+                                        "name": "SpotX",
+                                        "id": "218150"
+                                    }
+                                ]
+                            }
+                        }
+                    });
+            </code>
+        </pre>
+</div>
+<div class="pageDescription">
+    <p>This page demonstrates JW Player's new SpotX bidding integration. This is placeholder text for now to see what this looks like.</p>
+</div>

--- a/demos/advanced/video-player-bidding/index.html
+++ b/demos/advanced/video-player-bidding/index.html
@@ -34,67 +34,58 @@
         </div>
     </div>
     <h1 id="title">Code Example</h1>
-        <pre>
-            <code id="dfp">
-            var playerInstance = jwplayer("myElement")
-            playerInstance.setup({
-                "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",
-                "advertising": {
-                    "client": "googima",
-                    "schedule": {
-                        "adBreak": {
-                            "tag": "//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=sample_ct%3Dskippablelinear&correlator=",
-                            "offset": "pre"
-                        }
-                    },
-                    "bids": {
-                        "settings": {
-                            "mediationLayerAdServer": "dfp",
-                            "floorPriceCents": 2,
-                            "floorPriceCurrency": "usd",
-                            "bidTimeout": 1000
-                        },
-                        "bidders": [
-                            {
-                                "name": "SpotX",
-                                "id": "218150"
-                            }
-                        ]
-                    }
+        <pre><code id="dfp">var playerInstance = jwplayer("myElement")
+playerInstance.setup({
+    "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",
+    "advertising": {
+        "client": "googima",
+        "schedule": {
+            "adBreak": {
+                "tag": "//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=sample_ct%3Dskippablelinear&correlator=",
+                "offset": "pre"
+            }
+        },
+        "bids": {
+            "settings": {
+                "mediationLayerAdServer": "dfp",
+                "floorPriceCents": 2,
+                "floorPriceCurrency": "usd",
+                "bidTimeout": 1000
+            },
+            "bidders": [
+                {
+                    "name": "SpotX",
+                    "id": "218150"
                 }
-            });
-            </code>
-            <code id="jwp">
-                    var playerInstance = jwplayer("myElement")
-                    playerInstance.setup({
-                        "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",
-                        "advertising": {
-                            "client": "googima",
-                            "schedule": {
-                                "adBreak": {
-                                    "tag": "//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=sample_ct%3Dskippablelinear&correlator=",
-                                    "offset": "pre"
-                                }
-                            },
-                            "bids": {
-                                "settings": {
-                                    "mediationLayerAdServer": "jwp",
-                                    "floorPriceCents": 2,
-                                    "floorPriceCurrency": "usd",
-                                    "bidTimeout": 1000
-                                },
-                                "bidders": [
-                                    {
-                                        "name": "SpotX",
-                                        "id": "218150"
-                                    }
-                                ]
-                            }
-                        }
-                    });
-            </code>
-        </pre>
+            ]
+        }
+    }
+});</code><code id="jwp">var playerInstance = jwplayer("myElement")
+playerInstance.setup({
+    "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",
+    "advertising": {
+        "client": "googima",
+        "schedule": {
+            "adBreak": {
+                "tag": "//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=sample_ct%3Dskippablelinear&correlator=",
+                "offset": "pre"
+            }
+        },
+        "bids": {
+            "settings": {
+                "mediationLayerAdServer": "jwp",
+                "floorPriceCents": 2,
+                "floorPriceCurrency": "usd",
+                "bidTimeout": 1000
+            },
+            "bidders": [
+                {
+                    "name": "SpotX",
+                    "id": "218150"
+                }
+            ]
+        }
+    }
+});</code></pre>
 </div>
-<div class="pageDescription">
-    <p>This page demonstrates JW Player's new SpotX bidding integration. This is placeholder text for now to see what this looks like.</p>
-</div>
+

--- a/demos/advanced/video-player-bidding/js/main.js
+++ b/demos/advanced/video-player-bidding/js/main.js
@@ -1,0 +1,109 @@
+var playerInstance = jwplayer("myElement")
+let mediationLayer = "dfp"
+
+const configs = {
+    "jwp": {
+            "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",
+            "advertising": {
+                "client": "googima",
+                "schedule": {
+                    "adBreak": {
+                        "tag": "//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=sample_ct%3Dskippablelinear&correlator=",
+                        "offset": "pre"
+                    }
+                },
+                "bids": {
+                    "settings": {
+                        "mediationLayerAdServer": "jwp",
+                        "floorPriceCents": 2,
+                        "floorPriceCurrency": "usd",
+                        "bidTimeout": 1000
+                    },
+                    "bidders": [
+                        {
+                            "name": "SpotX",
+                            "id": "218150"
+                        }
+                    ]
+                }
+            }
+        },
+    "dfp": {
+        "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",
+        "advertising": {
+            "client": "googima",
+            "schedule": {
+                "adBreak": {
+                    "tag": "//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=sample_ct%3Dskippablelinear&correlator=",
+                    "offset": "pre"
+                }
+            },
+            "bids": {
+                "settings": {
+                    "mediationLayerAdServer": "dfp",
+                    "floorPriceCents": 2,
+                    "floorPriceCurrency": "usd",
+                    "bidTimeout": 1000
+                },
+                "bidders": [
+                    {
+                        "name": "SpotX",
+                        "id": "218150"
+                    }
+                ]
+            }
+        }
+    }
+}
+
+function setupPlayer() {
+    playerInstance.setup(configs[mediationLayer]);
+
+    
+    playerInstance.on("adImpression",function(event){
+        setElement("impression", "The ad impression was fired. SpotX did " + (winner(event)? ' ' : 'NOT') + " win the bidding.");
+    });
+
+    playerInstance.on("adBidRequest",function(event){
+        setElement("bid-request", "The ad Bid Request was fired.");
+    });
+
+    playerInstance.on("adBidResponse",function(event){
+        setElement("bid-response", "The ad Bid Response was fired.");
+    });
+}
+
+function setupListeners() {
+    const select = document.getElementById("mediationLayerSelect");
+    select.addEventListener("change", swapCodeBlocks, false);
+}
+
+function setElement(element,message){
+    var div = document.getElementById(element);
+    div.innerHTML = message;
+    div.style.color = "#090";
+}
+
+function winner(event){
+    if(!event.bidders) return false;
+    event.bidders.forEach((bidder) => {
+        if (bidder === "SpotX" && bidder.winner) return true;
+    });
+    return false;
+}
+
+function swapCodeBlocks(event) {
+    oldMediationLayer = mediationLayer;
+    mediationLayer = event.target.value;
+    let setupBlock;
+
+    setupPlayer();
+
+    document.getElementById(mediationLayer).style.display = "block";
+    document.getElementById(oldMediationLayer).style.display = "none";
+}
+
+
+setupListeners();
+
+setupPlayer();


### PR DESCRIPTION
**Description**

This developer demo shows off the new SpotX Video Player Bidding integration. The purpose of the demo is to:

1.) Demonstrate the configuration block for video player bidding setup, specifically:
```
"bids": {
                                "settings": {
                                    "mediationLayerAdServer": "jwp",
                                    "floorPriceCents": 2,
                                    "floorPriceCurrency": "usd",
                                    "bidTimeout": 1000
                                },
                                "bidders": [
                                    {
                                        "name": "SpotX",
                                        "id": "218150"
                                    }
                                ]
                            }
```
2.) Demonstrate the configurations for the two mediation layers ('jwp' and 'dfp')
3.) Show when an adRequest was fired, an adImpression recorded, and whether or not SpotX won the bid. 

