### PR TITLE
removed 'code example' header

### DIFF
--- a/demos/toolbox/video-player-bidding/index.html
+++ b/demos/toolbox/video-player-bidding/index.html
@@ -33,7 +33,6 @@
             </select>
         </div>
     </div>
-    <h1 id="title">Code Example</h1>
         <pre><code id="dfp">var playerInstance = jwplayer("myElement")
 playerInstance.setup({
     "file": "https://content.jwplatform.com/videos/1g8jjku3-cIp6U8lV.mp4",


### PR DESCRIPTION
**Description**

This PR:
1.) Removes the 'Code Example' header from the page. 