### PR TITLE
Add dai link back

### DIFF
--- a/demos/toolbox/dai-integration/index.html
+++ b/demos/toolbox/dai-integration/index.html
@@ -15,8 +15,9 @@
 -->
 <script src="//content.jwplatform.com/libraries/lqsWlr4Z.js"></script>
 <div class="pageDescription">
-    <p>This page demonstrates JW Player's Google Dynamic Ad Insertion (DAI) Integration for server side ad insertion.</p> <p></p><!--  <br>For more information, see our <a href="https://support.jwplayer.com/customer/portal/articles/2932733-getting-started-with-google-dynamic-ad-insertion-dai-" target="_blank">Getting Started</a> guide.</p>
-</div> -->  
+    <p>This page demonstrates JW Player's Google Dynamic Ad Insertion (DAI) Integration for server side ad insertion.</p>
+    <p>For more information, see our <a href="https://support.jwplayer.com/articles/getting-started-with-dai" target="_blank">Getting Started with DAI</a> support article.</p>
+</div>
 <div id="myElement"></div>
 <div class="instructions">
     <div class="steps">


### PR DESCRIPTION
Reversing https://github.com/jwplayer/jwdeveloper-demos/pull/419/commits/18f265cd6d82206d6d68f9b5128383a9f7d3f6c3. Adding support article link back to DAI demo.

![bitmoji](https://render.bitstrips.com/v2/cpanel/3c97455d-0ce1-4ac8-82a0-601e6d6f6fd2-b45b220b-197f-4217-b13e-41ddde95ad95-v1.png?transparent=1&palette=1&width=246)