### PR TITLE
Fixed AdManager URL

### DIFF
--- a/demos/toolbox/freewheel/js/main.js
+++ b/demos/toolbox/freewheel/js/main.js
@@ -8,9 +8,9 @@ playerInstance.setup({
     client: 'freewheel',
     freewheel: {
       networkid: 90750,
-      serverid: 'https://demo.v.fwmrm.net/ad/g/1',
-      profileid: '90750:jw_html5_test',
-      sectionid: 'jw_test_site_section'
+      serverid: "https://demo.v.fwmrm.net/ad/g/1",
+      profileid: "90750:jw_html5_test",
+      sectionid: "jw_test_site_section"
     },
     adscheduleid: '12345',
     schedule: {


### PR DESCRIPTION
Previous AdManager URL was working locally but had a SSL cert when live. This one works on Squash so it should work.