### PR TITLE
Fixed adManagerUrl in FW Demo

### DIFF
--- a/demos/toolbox/freewheel/config.json
+++ b/demos/toolbox/freewheel/config.json
@@ -1,0 +1,14 @@
+{
+  "title": "Freewheel Advertising",
+  "description": "Using FreeWheel as your ad manager allows for leveraging the control FreeWheel's platform provides.",
+  "license": "Enterprise",
+  "showCode": true,
+  "layout": "vertical",
+  "apiCalls": [
+    ""
+  ],
+  "author": {
+  	"name": "Alex Bussey",
+  	"githubUsername": "waxidiotic"
+  }
+}

--- a/demos/toolbox/freewheel/css/style.css
+++ b/demos/toolbox/freewheel/css/style.css
@@ -1,0 +1,19 @@
+/* Add your CSS here
+Below are examples for how to customize the player skin
+*/
+
+
+/* Set the global Background color of the player elements */
+.jw-skin-seven .jw-background-color {
+	background: #0e4d8f !important;
+}
+
+/* Changes ONLY the color of the duration text in the controlbar */
+.jw-skin-seven .jw-text-duration {
+	color: rgba(255,255,255,.5) !important;
+}
+
+/* Changes ONLY the color of the buffer bar in the timeslider */
+.jw-skin-seven .jw-buffer {
+	background: rgba(255,255,255,.5) !important; 
+}

--- a/demos/toolbox/freewheel/index.html
+++ b/demos/toolbox/freewheel/index.html
@@ -1,0 +1,28 @@
+<!--
+* Copyright 2016 Longtail Ad Solutions Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language
+* governing permissions and limitations under the License.
+-->
+
+<!-- This demo uses a single line embed. It contains a MediaID and PlayerID.
+
+You can set up a demo using our sample video and player or input your own.
+Ex: //content.jwplatform.com/players/{MediaID}-{PlayerID}.js
+
+MediaID and PlayerID are available in your Account Dashboard. -->
+
+<script src="//content.jwplatform.com/libraries/jEKBHz28.js"></script>
+
+<div id="player"></div>
+
+<p>Using FreeWheel as your ad manager requires an existing relationship with FreeWheel and access to the FreeWheel dashboard for configuration. Note that no ad tag is supplied to the player, rather values that link up to the setup configured within the FreeWheel platform.</p>

--- a/demos/toolbox/freewheel/js/main.js
+++ b/demos/toolbox/freewheel/js/main.js
@@ -1,0 +1,28 @@
+const playerInstance = jwplayer('player');
+
+playerInstance.setup({
+  file: '//content.jwplatform.com/videos/3XnJSIm4-injeKYZS.mp4',
+  fwassetid: 'jw_test_asset_g',
+  duration: 500,
+  advertising: {
+    client: 'freewheel',
+    freewheel: {
+      networkid: 90750,
+      // The 'adManagerUrl' specified below should
+      // be the URL you receive from Freewheel.
+      adManagerUrl: "https://mssl.fwmrm.net/p/jw_html5_test/AdManager.js",
+      serverid: "https://demo.v.fwmrm.net/ad/g/1",
+      profileid: "90750:jw_html5_test",
+      sectionid: "jw_test_site_section"
+    },
+    adscheduleid: '12345',
+    schedule: {
+      adbreak: {
+        offset: 'pre',
+        tag: 'placeholder_preroll'
+      }
+    },
+    vpaidcontrols: true,
+    skipoffset: 3
+  }
+});


### PR DESCRIPTION
This PR will....

add a developer demo to showcase the Freewheel ad plugin. There is no extra, special functionality added to this demo - it just makes a request for the Freewheel ad and plays it.