### PR TITLE
Changed FW Asset ID in Demo Config

### DIFF
--- a/demos/toolbox/freewheel/js/main.js
+++ b/demos/toolbox/freewheel/js/main.js
@@ -2,7 +2,7 @@ const playerInstance = jwplayer('player');
 
 playerInstance.setup({
   file: '//content.jwplatform.com/videos/3XnJSIm4-injeKYZS.mp4',
-  fwassetid: 'jw_test_asset_g',
+  fwassetid: 'jw_test_asset_h',
   duration: 500,
   advertising: {
     client: 'freewheel',


### PR DESCRIPTION
DOCS-49

**Change**
Switched `fwassetid` from `jw_test_asset_g` to `jw_test_asset_h`.

**Reason Why**
Freewheel did something on their end that broke our old demo asset which caused the demo not to work.