### PR TITLE
Replace player library URL on ad rules demo

### DIFF
--- a/build/advanced/ad-rules/index.html
+++ b/build/advanced/ad-rules/index.html
@@ -92,7 +92,7 @@ Ex: //content.jwplatform.com/players/{MediaID}-{PlayerID}.js
 
 MediaID and PlayerID are available in your Account Dashboard. -->
 
-<script src="https://content.jwplatform.com/libraries/jEKBHz28.js"></script>
+<script src="https://content.jwplatform.com/libraries/lqsWlr4Z.js"></script>
 
 <div id="player"></div>
 

--- a/build/template-css/jw-demos.css
+++ b/build/template-css/jw-demos.css
@@ -349,25 +349,25 @@ Markdown
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 300;
-  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v15/mem5YaGs126MiZpBA-UN_r8OUuhs.ttf) format('truetype');
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v16/mem5YaGs126MiZpBA-UN_r8OUuhs.ttf) format('truetype');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v15/mem8YaGs126MiZpBA-UFVZ0e.ttf) format('truetype');
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v16/mem8YaGs126MiZpBA-UFVZ0e.ttf) format('truetype');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
-  src: local('Open Sans SemiBold'), local('OpenSans-SemiBold'), url(https://fonts.gstatic.com/s/opensans/v15/mem5YaGs126MiZpBA-UNirkOUuhs.ttf) format('truetype');
+  src: local('Open Sans SemiBold'), local('OpenSans-SemiBold'), url(https://fonts.gstatic.com/s/opensans/v16/mem5YaGs126MiZpBA-UNirkOUuhs.ttf) format('truetype');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v15/mem5YaGs126MiZpBA-UN7rgOUuhs.ttf) format('truetype');
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v16/mem5YaGs126MiZpBA-UN7rgOUuhs.ttf) format('truetype');
 }
 *,
 *:before,

--- a/demos/advanced/ad-rules/index.html
+++ b/demos/advanced/ad-rules/index.html
@@ -21,7 +21,7 @@ Ex: //content.jwplatform.com/players/{MediaID}-{PlayerID}.js
 
 MediaID and PlayerID are available in your Account Dashboard. -->
 
-<script src="https://content.jwplatform.com/libraries/jEKBHz28.js"></script>
+<script src="https://content.jwplatform.com/libraries/lqsWlr4Z.js"></script>
 
 <div id="player"></div>
 


### PR DESCRIPTION
Cloud-hosted player library on Ad Rules demo was 404'ing. Replacing URL.

@monibons - Not sure why building is updating the Open Sans font. Let me know if you want me to un-stage the CSS file.